### PR TITLE
EntityからFormに移送する処理を修正

### DIFF
--- a/src/main/java/com/c4c/_2022server/service/impl/ReserveHistoryServiceImpl.java
+++ b/src/main/java/com/c4c/_2022server/service/impl/ReserveHistoryServiceImpl.java
@@ -3,6 +3,7 @@ package com.c4c._2022server.service.impl;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -29,20 +30,7 @@ public class ReserveHistoryServiceImpl implements ReserveHistoryService {
         List<ReserveHistoryFormRes> resFormList = new ArrayList<>();
         for (ReserveHistory0001 reserveHistory0001 : reserveHistoryList) {
             ReserveHistoryFormRes resForm = new ReserveHistoryFormRes();
-            resForm.setReserveHistoryId(reserveHistory0001.getReserveHistoryId());
-            resForm.setRank(reserveHistory0001.getRank());
-            resForm.setMenu(reserveHistory0001.getMenu());
-            resForm.setPrice(reserveHistory0001.getPrice());
-            resForm.setReserveDatetime(reserveHistory0001.getReserveDatetime());
-            resForm.setReserveState(ReserveState.MAP.get(reserveHistory0001.getReserveState()));
-            resForm.setCustomerLastName(reserveHistory0001.getCustomerLastName());
-            resForm.setCustomerFirstName(reserveHistory0001.getCustomerFirstName());
-            resForm.setCustomerLastNameKana(reserveHistory0001.getCustomerLastNameKana());
-            resForm.setCustomerFirstNameKana(reserveHistory0001.getCustomerFirstNameKana());
-            resForm.setStuffLastName(reserveHistory0001.getStuffLastName());
-            resForm.setStuffFirstName(reserveHistory0001.getStuffFirstName());
-            resForm.setStuffLastNameKana(reserveHistory0001.getStuffLastNameKana());
-            resForm.setStuffFirstNameKana(reserveHistory0001.getStuffFirstNameKana());
+            BeanUtils.copyProperties(reserveHistory0001, resForm);
             resFormList.add(resForm);
         }
         return resFormList;


### PR DESCRIPTION
### ●修正内容
EntityからFormに移送する処理を
```
BeanUtils.copyProperties()
```
を使用する形に修正。